### PR TITLE
Namespace option as function

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,6 @@
     "no-dupe-keys": 2,
     "no-else-return": 2,
     "no-empty": 2,
-    "no-empty-label": 2,
     "no-eq-null": 0,
     "no-eval": 2,
     "no-ex-assign": 2,
@@ -58,7 +57,7 @@
     "no-lone-blocks": 2,
     "no-lonely-if": 2,
     "no-loop-func": 2,
-    "no-magic-numbers": 2,
+    "no-magic-numbers": 0,
     "no-mixed-requires": [0, false],
     "no-multi-str": 2,
     "no-multiple-empty-lines": 2,
@@ -130,17 +129,15 @@
     "computed-property-spacing": [ 2, "never" ],
     "object-curly-spacing": [ 2, "always" ],
     "array-bracket-spacing": [ 2, "always" ],
-    "space-after-keywords": 2,
     "space-infix-ops": 2,
     "space-in-parens": [ 2, "never" ],
-    "space-return-throw-case": 2,
     "space-unary-ops": [2, {"words": true, "nonwords": false}],
     "space-before-blocks": 2,
-    "space-before-keywords": [ 2, "always" ],
     "use-isnan": 2,
     "valid-jsdoc": 2,
     "wrap-iife": 0,
     "wrap-regex": 0,
-    "vars-on-top": 2
+    "vars-on-top": 2,
+    "keyword-spacing": 2
   }
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -17,22 +17,24 @@ module.exports = postcss.plugin('postcss-selector-namespace', (options = {}) => 
         return
       }
 
-      const namespaceString = typeof namespace === 'string' ? namespace : namespace(css.source.input.file)
+      const computedNamespace = typeof namespace === 'string' ? namespace : namespace(css.source.input.file)
 
-      rule.selectors = rule.selectors.map(selector => namespaceSelector(selector, namespaceString))
+      if (computedNamespace) {
+        rule.selectors = rule.selectors.map(selector => namespaceSelector(selector, computedNamespace))
+      }
     })
   }
 
-  function namespaceSelector(selector, namespaceString) {
+  function namespaceSelector(selector, computedNamespace) {
     if (hasSelfSelector(selector)) {
-      return selector.replace(selfSelector, namespaceString)
+      return selector.replace(selfSelector, computedNamespace)
     }
 
     if (hasRootSelector(selector)) {
       return dropRootSelector(selector)
     }
 
-    return `${namespaceString} ${selector}`
+    return `${computedNamespace} ${selector}`
   }
 
   function hasSelfSelector(selector) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -17,20 +17,22 @@ module.exports = postcss.plugin('postcss-selector-namespace', (options = {}) => 
         return
       }
 
-      rule.selectors = rule.selectors.map(namespaceSelector)
+      const namespaceString = typeof namespace === 'string' ? namespace : namespace(css.source.input.file)
+
+      rule.selectors = rule.selectors.map(selector => namespaceSelector(selector, namespaceString))
     })
   }
 
-  function namespaceSelector(selector) {
+  function namespaceSelector(selector, namespaceString) {
     if (hasSelfSelector(selector)) {
-      return selector.replace(selfSelector, namespace)
+      return selector.replace(selfSelector, namespaceString)
     }
 
     if (hasRootSelector(selector)) {
       return dropRootSelector(selector)
     }
 
-    return `${namespace} ${selector}`
+    return `${namespaceString} ${selector}`
   }
 
   function hasSelfSelector(selector) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "prepublish": "babel lib --out-dir dist",
-    "test": "babel-node node_modules/.bin/babel-istanbul cover _mocha -- tests/test.js",
+    "test": "babel-node node_modules/babel-istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- tests/test.js",
     "lint": "eslint lib/* tests/*"
   },
   "repository": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,5 @@
 import fs                       from 'fs'
+import path                     from 'path'
 import { expect }               from 'chai'
 import postcss                  from 'postcss'
 import postcssSelectorNamespace from '../lib/plugin'
@@ -58,6 +59,15 @@ describe('Basic functionality', () => {
     )
 
     expect(String(css)).to.equal('.foo .my-component {}')
+  })
+
+  it('can accept a function for the namespace option', () => {
+    let { css } = transform(
+      '.foo {}',
+      { namespace: file => '.' + path.basename(file, '.css') },
+      { from: 'bar.css' }
+    )
+    expect(String(css)).to.equal('.bar .foo {}')
   })
 })
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -69,6 +69,14 @@ describe('Basic functionality', () => {
     )
     expect(String(css)).to.equal('.bar .foo {}')
   })
+
+  it('does not apply if computed namespace is falsy', () => {
+    let { css } = transform(
+      '.foo {}',
+      { namespace: file => !!file }
+    )
+    expect(String(css)).to.equal('.foo {}')
+  })
 })
 
 describe(':root', () => {


### PR DESCRIPTION
Fixes issue #4 and includes tests.

Also fixes some linting errors (replaced some deprecated rules, disabled one rule) and makes the test script run ok on Windows (by referencing js files instead of shell scripts).

I don't use Yarn yet, so I'm not sure what if anything needs to change in the yarn.lock file ... 